### PR TITLE
Add translation info to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,20 @@ description: Never worry about forgetting things again.
 	<section>
 		<div class="container flex">
 			<div class="image">
+				<a href="https://hosted.weblate.org/engage/planner/?utm_source=widget">
+				<img src="https://hosted.weblate.org/widgets/planner/-/287x66-white.png"  alt="Planner Translations" class="screenshot editable" />
+				</a>
+			</div>
+			<div class="text editable">
+				<h2>Use Planner in your <strong>Language</strong></h2>
+				<p>Planner has been translated into several languages already. If your language is still missing or incomplete, please use Weblate to help translate Planner.</p>
+			</div>
+		</div>
+	</section>
+
+	<section>
+		<div class="container flex">
+			<div class="image">
 				<img src="{{ site.baseurl }}/images/PlannerToday.png" alt="Planner Calendar Events" class="screenshot editable" />
 			</div>
 			


### PR DESCRIPTION
I simply added a new `<section>` to the index.html page.
It's just a suggestion. If you don't like it, discard it ;-)
See issue #3 
